### PR TITLE
Travis CI checks for Node 10 & 12 Added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,16 @@
-sudo: false
 language: node_js
+
 node_js:
   - "8.6.0"
-notifications:
-  disabled: true
+  - "lts/carbon"
+  - "lts/dubnium"
+  - "node"
+
+sudo: false
+
+install:
+  - "npm install"
+
+os:
+  - "linux"
+  - "osx"


### PR DESCRIPTION
* Addresses #21 by ensuring [Travis CI](https://travis-ci.org/) tests run for Node 10 and 12 latest releases.
* Removes unnecessary cruft from `./.travis.yml`.